### PR TITLE
Ajout du champ `auteur_pseudo` dans les carrousels et écrans

### DIFF
--- a/src/components/home/Carrousel.astro
+++ b/src/components/home/Carrousel.astro
@@ -10,6 +10,7 @@ type CarrouselImage = {
     jeu: string,
     nom_serveur: string,
     carrousel: boolean,
+    auteur_pseudo: string,
 };
 
 // Fonction de mélange
@@ -44,6 +45,7 @@ try {
             jeu: img.jeu,
             nom_serveur: img.nom_serveur,
             carrousel: img.carrousel,
+            auteur_pseudo: img.auteur_pseudo,
         }));
 
     palworldImages = images
@@ -57,6 +59,7 @@ try {
             jeu: img.jeu,
             nom_serveur: img.nom_serveur,
             carrousel: img.carrousel,
+            auteur_pseudo: img.auteur_pseudo,
         }));
 
 } catch (error) {
@@ -119,7 +122,7 @@ const games = [
                                 />
                             <!-- Crédit de l'image -->
                                 <div class="carousel-auteur absolute bottom-4 left-4 text-white text-sm bg-black/40 px-3 py-1 rounded opacity-0 transition-opacity duration-500">
-                                    <p>Image par {src.auteur} sur le serveur : {src.nom_serveur}</p>
+                                    <p>Par {src.auteur_pseudo} sur {src.nom_serveur}</p>
                                 </div>
                         ))}
 
@@ -141,7 +144,6 @@ const games = [
                                             class={`game-icon text-6xl cursor-pointer transform transition duration-300`}
                                             data-index={idx}
                                     >
-
                                         <!-- Icone des jeux -->
                                         <Image
                                                 src={g.icon}

--- a/src/components/serveurs/ServeurScreen.astro
+++ b/src/components/serveurs/ServeurScreen.astro
@@ -1,5 +1,11 @@
 ---
 const {screenList} = Astro.props;
+
+type Screen = {
+    nom: string;
+    auteur_pseudo: string;
+    path: string;
+}
 ---
 <!-- CSS -->
 <style>
@@ -55,10 +61,10 @@ const {screenList} = Astro.props;
 
 <!-- Contenu de la page -->
 <div class="serveur-screen">
-    {screenList.map((screen) => (
+    {screenList.map((screen: Screen) => (
             <div class="screen-item">
                 <img src={screen.path} alt={screen.nom}/>
-                <p class="author">Par : {screen.auteur || "Inconnu"}</p>
+                <p class="author">Par : {screen.auteur_pseudo || "Inconnu"}</p>
             </div>
     ))}
 </div>


### PR DESCRIPTION
- Mise à jour des types pour inclure `auteur_pseudo` dans les carrousels et serveurs.
- Modification de l'affichage des crédits pour utiliser `auteur_pseudo` au lieu de `auteur` ou autres champs.
- Ajustement des filtres et transformations pour prendre en compte le nouveau champ.